### PR TITLE
Expand arrays of objects

### DIFF
--- a/templates/partials/property.html
+++ b/templates/partials/property.html
@@ -1,10 +1,17 @@
 <tr class="table__body__row">
   <td class="table__body__cell">{{{tree path}}}{{propName}} {{#if ./required}}<span class="required-badge">(Required)</span>{{/if}}</td>
-  <td class="table__body__cell">{{prop.type}}</td>
+  <td class="table__body__cell">{{prop.type}}{{#if prop.items.type}}({{prop.items.type}}){{/if}}</td>
   <td class="table__body__cell">{{prop.description}}</td>
 </tr>
 {{#if prop.properties}}
   {{#each prop.properties}}
   {{> property prop=. propName=@key path=(concat ../path @key '.')}}
   {{/each}}
+{{/if}}
+{{#if prop.items}}
+  {{#if prop.items.properties}}
+    {{#each prop.items.properties}}
+    {{> property prop=. propName=@key path=(concat ../path @key '.')}}
+    {{/each}}
+  {{/if}}
 {{/if}}

--- a/templates/partials/schema-prop.html
+++ b/templates/partials/schema-prop.html
@@ -1,7 +1,7 @@
 <tr class="table__body__row">
   <td class="table__body__cell">{{{tree path}}}{{propName}} {{#if ./required}}<span class="required-badge">(Required)</span>{{/if}}</td>
   <td class="table__body__cell">{{prop.title}}</td>
-  <td class="table__body__cell">{{prop.type}}</td>
+  <td class="table__body__cell">{{prop.type}}{{#if prop.items.type}}({{prop.items.type}}){{/if}}</td>
   <td class="table__body__cell">{{prop.format}}</td>
   <td class="table__body__cell">{{prop.default}}</td>
   <td class="table__body__cell">{{prop.description}}</td>
@@ -10,4 +10,11 @@
   {{#each prop.properties}}
   {{> schemaProp prop=. propName=@key path=(concat ../path @key '.')}}
   {{/each}}
+{{/if}}
+{{#if prop.items}}
+  {{#if prop.items.properties}}
+    {{#each prop.items.properties}}
+    {{> property prop=. propName=@key path=(concat ../path @key '.')}}
+    {{/each}}
+  {{/if}}
 {{/if}}


### PR DESCRIPTION
This fixes #6

<img width="681" alt="screen shot 2017-08-01 at 14 26 45" src="https://user-images.githubusercontent.com/242119/28825176-804f806c-76c5-11e7-83b2-42801b5ec0f5.png">

It now expands arrays of objects and makes it clear it's an array of objects by changing the type to `array(object)`.