### PR TITLE
Allow separator mixing

### DIFF
--- a/lib/beautifier.js
+++ b/lib/beautifier.js
@@ -54,11 +54,9 @@ module.exports = (asyncapi) => {
 
   _.each(asyncapi.topics, (topic, topicName) => {
     const separator = asyncapi['x-topic-separator'] || '.';
-    const baseTopic = asyncapi.baseTopic.trim().replace(/\./g, separator);
+    const baseTopic = asyncapi.baseTopic.trim();
 
-    let newTopicName = topicName.replace(/\./g, separator);
-    if (baseTopic.length) newTopicName = `${baseTopic}${separator}${newTopicName}`;
-
+    let newTopicName = baseTopic.length ? `${baseTopic}${separator}${topicName}` : topicName;
     if (newTopicName !== topicName) {
       asyncapi.topics[newTopicName] = topic;
       delete asyncapi.topics[topicName];


### PR DESCRIPTION
In the current implementation, it is not possible to change the
`x-topic-separator` to something else, without having this
'something else' beeing rewritten to the separator.

Example:

Setting `x-topic-separator` to '/' for MQTT style topics, it is
not possible to get this topic in the documentation:

  `foo/devices/1.0/{serial}/join`

It is always rewritten to:

  `foo/devices/1/0/{serial}/join`

This PR changes this behaviour. Hopefully without shredding
something else, because the npm tests are not existent ;-)