### PR TITLE
Fix rendering of required fields

### DIFF
--- a/lib/helpers/handlebars.js
+++ b/lib/helpers/handlebars.js
@@ -34,3 +34,10 @@ Handlebars.registerHelper('inc', (number) => {
 Handlebars.registerHelper('log', (something) => {
   console.log(require('util').inspect(something, { depth: null }));
 });
+
+Handlebars.registerHelper('contains', (array, element) => {
+  if (array == null) {
+    return false
+  }
+  return array.indexOf(element) >= 0
+})

--- a/templates/partials/schema-prop.html
+++ b/templates/partials/schema-prop.html
@@ -29,7 +29,7 @@
 {{#if prop.items}}
   {{#if prop.items.properties}}
     {{#each prop.items.properties}}
-    {{> schemaProp prop=. propName=@key path=(concat ../path @key '.') required=(contains ../prop.required @key)}}
+    {{> schemaProp prop=. propName=@key path=(concat ../path @key '.') required=(contains ../prop.items.required @key)}}
     {{/each}}
   {{/if}}
 {{/if}}

--- a/templates/partials/schema-prop.html
+++ b/templates/partials/schema-prop.html
@@ -1,5 +1,5 @@
 <tr class="table__body__row">
-  <td class="table__body__cell">{{{tree path}}}{{propName}} {{#if ./required}}<span class="required-badge">(Required)</span>{{/if}}</td>
+  <td class="table__body__cell">{{{tree path}}}{{propName}} {{#if required}}<span class="required-badge">(Required)</span>{{/if}}</td>
   <td class="table__body__cell">{{prop.title}}</td>
   <td class="table__body__cell">
     {{prop.type}}
@@ -13,23 +13,23 @@
 </tr>
 {{#if prop.anyOf}}
   {{#each prop.anyOf}}
-    {{> schemaProp prop=. propName=@key path=(concat ../path @key '.')}}
+    {{> schemaProp prop=. propName=@key path=(concat ../path @key '.') required=(contains ../prop.required @key)}}
   {{/each}}
 {{/if}}
 {{#if prop.oneOf}}
   {{#each prop.oneOf}}
-    {{> schemaProp prop=. propName=@key path=(concat ../path @key '.')}}
+    {{> schemaProp prop=. propName=@key path=(concat ../path @key '.') required=(contains ../prop.required @key)}}
   {{/each}}
 {{/if}}
 {{#if prop.properties}}
   {{#each prop.properties}}
-  {{> schemaProp prop=. propName=@key path=(concat ../path @key '.')}}
+  {{> schemaProp prop=. propName=@key path=(concat ../path @key '.') required=(contains ../prop.required @key)}}
   {{/each}}
 {{/if}}
 {{#if prop.items}}
   {{#if prop.items.properties}}
     {{#each prop.items.properties}}
-    {{> schemaProp prop=. propName=@key path=(concat ../path @key '.')}}
+    {{> schemaProp prop=. propName=@key path=(concat ../path @key '.') required=(contains ../prop.required @key)}}
     {{/each}}
   {{/if}}
 {{/if}}

--- a/templates/partials/schema.html
+++ b/templates/partials/schema.html
@@ -17,9 +17,9 @@
     </thead>
     <tbody class="table__body">
       {{#each schema.properties}}
-        {{> schemaProp prop=. propName=@key}}
+        {{> schemaProp prop=. propName=@key required=(contains ../schema.required @key)}}
       {{else}}
-        {{> schemaProp prop=schema propName=schemaName}}
+        {{> schemaProp prop=schema propName=schemaName required=(contains ../schema.required @key)}}
       {{/each}}
     </tbody>
   </table>


### PR DESCRIPTION
## Context
This PR fixes #27 

## Idea

**Given** rendering properties of `SchemaObject`
**When** `required` array of SchemaObject  contains property name
**Then** pass boolean parameter to `schema-prop` template.

The same flow is applied for nested parameter objects in `schema-prop` template

## Implementation
* Add `contains` Handlebars helper to check that if array contains a specific element
* Update `schema.prop.html` to use boolean `required` parameter  to render `(Required)` label
* Update all usages of `schema.prop.html` to calculate `required` parameter from current context 
